### PR TITLE
Update Box Oauth end point url

### DIFF
--- a/CloudFS.Gateways.Box/OAuth/OAuthAuthenticator.cs
+++ b/CloudFS.Gateways.Box/OAuth/OAuthAuthenticator.cs
@@ -41,9 +41,9 @@ namespace IgorSoft.CloudFS.Gateways.Box.OAuth
     {
         private const string BOX_LOGIN_DESKTOP_URI = "https://localhost/box_login";
 
-        private const string BOX_LOGIN_AUTHORIZE_URI = "https://app.box.com/api/oauth2/authorize";
+        private const string BOX_LOGIN_AUTHORIZE_URI = "https://account.box.com/api/oauth2/authorize";
 
-        private const string BOX_LOGIN_TOKEN_URI = "https://app.box.com/api/oauth2/token";
+        private const string BOX_LOGIN_TOKEN_URI = "https://account.box.com/api/oauth2/token";
 
         private const string BOX_API_URI = "https://api.box.com/2.0";
 

--- a/CloudFS.Gateways.Box/OAuth/OAuthAuthenticator.cs
+++ b/CloudFS.Gateways.Box/OAuth/OAuthAuthenticator.cs
@@ -43,7 +43,7 @@ namespace IgorSoft.CloudFS.Gateways.Box.OAuth
 
         private const string BOX_LOGIN_AUTHORIZE_URI = "https://account.box.com/api/oauth2/authorize";
 
-        private const string BOX_LOGIN_TOKEN_URI = "https://account.box.com/api/oauth2/token";
+        private const string BOX_LOGIN_TOKEN_URI = "https://api.box.com/api/oauth2/token";
 
         private const string BOX_API_URI = "https://api.box.com/2.0";
 


### PR DESCRIPTION
I've had some issue not able to create authtokens with app.box.com:
Updating Auth token URL as per Box API docs. 
https://docs.box.com/reference#token
```
https://account.box.com/api/oauth2/authorize
https://api.box.com/oauth2/token
```